### PR TITLE
Support for Storage Scale 5.1.8. Complete rename to Storage Scale.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ boxes/*.box
 */*/*.box
 disk/
 software/Spectrum_Scale_*
+software/Storage_Scale_*
 aws/Vagrantfile.aws-credentials
 aws/Vagrantfile.aws-ami

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ The scripts and configuration files provision a single node IBM Storage Scale cl
 ### Get the scripts and configuration files from GitHub
 
 Open a Command Prompt and clone the GitHub repository:
-1. `git clone https://github.com/IBM/SpectrumScaleVagrant.git`
-1. `cd SpectrumScaleVagrant`
+1. `git clone https://github.com/IBM/StorageScaleVagrant.git`
+1. `cd StorageScaleVagrant`
 
 ### Get the Storage Scale self-extracting installation package
 
@@ -18,8 +18,8 @@ The creation of the Storage Scale cluster requires the Storage Scale
 self-extracting installation package. The developer edition can be downloaded
 from the [Storage Scale home page](https://www.ibm.com/products/storage-scale).
 
-Download the `Spectrum_Scale_Developer-5.1.7.1-x86_64-Linux-install` package and
-save it to directory `SpectrumScaleVagrant/software` on the `host`.
+Download the `Storage_Scale_Developer-5.1.8.0-x86_64-Linux-install` package and
+save it to directory `StorageScaleVagrant/software` on the `host`.
 
 Please note that in case the Storage Scale Developer version you downloaded is
 newer than the one we listed here, you still might want to use the new
@@ -53,7 +53,7 @@ preferred provider to install and configure a virtual machine.
 
 Please note that for AWS you might want to prefer the new "Cloudkit" Storage
 Scale capability that is also available with the Storage Scale Developer Edition.
-For more details about Cloudkit, please refer to the [documentation](https://www.ibm.com/docs/en/spectrum-scale/5.1.7?topic=reference-cloudkit).
+For more details about Cloudkit, please refer to the [documentation](https://www.ibm.com/docs/en/storage-scale/5.1.8?topic=reference-cloudkit).
 
 Once the virtual environment is provided, Storage Scale Vagrant uses the same
 scripts to install and configure Storage Scale. Storage Scale Vagrant executes
@@ -340,5 +340,5 @@ Maximum number of inodes:       107520
 
 **Please note:** This project is released for use "AS IS" without any warranties of any kind, including, but not limited to installation, use, or performance of the resources in this repository.
 We are not responsible for any damage, data loss or charges incurred with their use.
-This project is outside the scope of the IBM PMR process. If you have any issues, questions or suggestions you can create a new issue [here](https://github.com/IBM/SpectrumScaleVagrant/issues).
+This project is outside the scope of the IBM PMR process. If you have any issues, questions or suggestions you can create a new issue [here](https://github.com/IBM/StorageScaleVagrant/issues).
 Issues will be addressed as team availability permits.

--- a/aws/README.md
+++ b/aws/README.md
@@ -46,7 +46,7 @@ vagrant box add aws-dummy https://github.com/mitchellh/vagrant-aws/raw/master/du
 Copy the `Vagrantfile.aws-credentials.sample` to `Vagrantfile.aws-credentials` and update that file with your credentials:
 
 ```
-cd SpectrumScaleVagrant\aws
+cd StorageScaleVagrant\aws
 copy Vagrantfile.aws-credentials.sample Vagrantfile.aws-credentials
 notepad Vagrantfile.aws-credentials
 ```
@@ -64,58 +64,58 @@ and to subscribe it in order to accept the license agreement.
 ## Decide on how to integrate the Storage Scale self-extracting installation package
 
 Depending on your network connectivity, it takes some time to upload the Storage Scale self-extracting installation package into AWS. There are two approach options to optimize the creation of the AWS AMI image for Storage Scale:
-1. Save the self-extracting installation package to `SpectrumScaleVagrant\software` before you to boot the virtual machine from which you create the Storage Scale AWS AMI. Then Vagrant will automatically copy it during the provisioning process (`Vagrant up`) from your host to the virtual machine in AWS.
+1. Save the self-extracting installation package to `StorageScaleVagrant\software` before you to boot the virtual machine from which you create the Storage Scale AWS AMI. Then Vagrant will automatically copy it during the provisioning process (`Vagrant up`) from your host to the virtual machine in AWS.
 1. Copy the self-extracting installation package to `/software` of your virtual machine, after you have booted it. This approach is faster, if you have a copy for instance in an S3 bucket.
 
-## Spectrum Scale Base AMI - An AWS AMI optimized for Storage Scale
+## Storage Scale Base AMI - An AWS AMI optimized for Storage Scale
 
 The virtual machines are based on the official CentOS/8 AWS AMI. Storage Scale requires a couple of additional RPMs. We create a custom Storage Scale Base AMI to accelerate the provisioning of the virtual machines for the Storage Scale environment.
 
 To start the initial virtual machine:
-1. `cd SpectrumScaleVagrant\aws\prep-ami`
+1. `cd StorageScaleVagrant\aws\prep-ami`
 1. `Vagrant up`
 1. `Vagrant ssh`
 
 Copy the Storage Scale self-extracting installation package to `/software`, if you decided for approach option 2 above.
 
 ```
-SpectrumScaleVagrant\aws\prep-ami>vagrant ssh
+StorageScaleVagrant\aws\prep-ami>vagrant ssh
 
 [centos@ip-172-31-27-143 ~]$ ls -l software/
 total 1527996
--rw-r--r--. 1 centos centos        134  4. Apr 12:22 README
--rw-r--r--. 1 centos centos 1564715222 11. Apr 01:42 Spectrum_Scale_Developer-5.1.7.1-x86_64-Linux-install
--rw-r--r--. 1 centos centos         88 11. Apr 01:42 Spectrum_Scale_Developer-5.1.7.1-x86_64-Linux-install.md5
+-rw-r--r--.  1 centos centos        134 31. Mai 11:32 README
+-rwxr-xr-x.  1 centos centos 1568773648 24. Mai 01:03 Storage_Scale_Developer-5.1.8.0-x86_64-Linux-install
+-rw-r--r--.  1 centos centos         87 24. Mai 01:03 Storage_Scale_Developer-5.1.8.0-x86_64-Linux-install.md5
 
 [centos@ip-172-31-27-143 ~]$ exit
 logout
 Connection to ec2-34-224-86-55.compute-1.amazonaws.com closed.
 
-SpectrumScaleVagrant\aws\prep-ami>
+StorageScaleVagrant\aws\prep-ami>
 ```
 
 Having checked that `DeleteOnTermination` is set to `true` (see [Appendix](#appendix-avoid-orphaned-root-volumes)) we can build the Storage Scale AWS AMI and terminate the virtual machine:
-1. `vagrant package SpectrumScale_base --output SpectrumScale_base.box`
+1. `vagrant package StorageScale_base --output StorageScale_base.box`
 1. `vagrant destroy`
 
 If `vagrant package` fails with the error message `Malformed => AMI names must be between 3 and 128 characters long, and may contain letters, numbers, '(', ')', '.', '-', '/' and '_'`
 you need to apply a patch described in the [Appendix](#appendix-fix-for-vagrant-aws-packaging) to your local copy of vagrant-aws and try again.
 
 
-## Configure the SpectrumScale_base AMI ID
+## Configure the StorageScale_base AMI ID
 
-The `vagrant package ...` command of the previous step prints the AMI ID of the new SpectrumScale_base AMI:
+The `vagrant package ...` command of the previous step prints the AMI ID of the new StorageScale_base AMI:
 
 ```
 ...
-==> SpectrumScale_base: Waiting for the AMI 'ami-05d550f0ea6e84325' to burn...
+==> StorageScale_base: Waiting for the AMI 'ami-05d550f0ea6e84325' to burn...
 ...
 ```
 
-Copy the `Vagrantfile.aws-ami.sample` to `Vagrantfile.aws-ami` and update that file with the AMI ID of the SpectrumScale_base AMI:
+Copy the `Vagrantfile.aws-ami.sample` to `Vagrantfile.aws-ami` and update that file with the AMI ID of the StorageScale_base AMI:
 
 ```
-cd SpectrumScaleVagrant\aws
+cd StorageScaleVagrant\aws
 copy Vagrantfile.aws-ami.sample Vagrantfile.aws-ami
 notepad Vagrantfile.aws-ami
 ```
@@ -123,7 +123,7 @@ notepad Vagrantfile.aws-ami
 ## Boot a virtual machine with a single node Storage Scale cluster
 
 Now we are ready to boot a virtual machine on AWS and to configure it with a single node Storage Scale cluster:
-1. `cd SpectrumScaleVagrant\aws`
+1. `cd StorageScaleVagrant\aws`
 1. `vagrant up`
 1. `vagrant ssh`
 
@@ -138,7 +138,7 @@ Amazon charges for orphaned root volumes. They either need to be deleted manuall
 First step is to query the `InstanceId` and the setting for `DeleteOnTermination` of the running virtual machine:
 
 ```
-SpectrumScaleVagrant\aws\prep-ami>aws ec2 describe-instances --region us-east-1 --filters "Name=tag:Name,Values=SpectrumScaleVagrant*" --query "Reservations[*].Instances[*].[InstanceId,BlockDeviceMappings[*]]"
+StorageScaleVagrant\aws\prep-ami>aws ec2 describe-instances --region us-east-1 --filters "Name=tag:Name,Values=StorageScaleVagrant*" --query "Reservations[*].Instances[*].[InstanceId,BlockDeviceMappings[*]]"
 [
     [
         [
@@ -158,15 +158,15 @@ SpectrumScaleVagrant\aws\prep-ami>aws ec2 describe-instances --region us-east-1 
     ]
 ]
 
-SpectrumScaleVagrant\aws\prep-ami>
+StorageScaleVagrant\aws\prep-ami>
 ```
 
 Next step is to modify the setting for `DeleteOnTermination` and to validate that the setting was changed:
 
 ```
-SpectrumScaleVagrant\aws\prep-ami>aws ec2 modify-instance-attribute --instance-id "i-0dadfb6d892a0d83c" --region us-east-1 --block-device-mappings file://DeleteOnTermination.json
+StorageScaleVagrant\aws\prep-ami>aws ec2 modify-instance-attribute --instance-id "i-0dadfb6d892a0d83c" --region us-east-1 --block-device-mappings file://DeleteOnTermination.json
 
-SpectrumScaleVagrant\aws\prep-ami>aws ec2 describe-instances --region us-east-1 --filters "Name=tag:Name,Values=SpectrumScaleVagrant*" --query "Reservations[*].Instances[*].[InstanceId,BlockDeviceMappings[*]]"
+StorageScaleVagrant\aws\prep-ami>aws ec2 describe-instances --region us-east-1 --filters "Name=tag:Name,Values=StorageScaleVagrant*" --query "Reservations[*].Instances[*].[InstanceId,BlockDeviceMappings[*]]"
 [
     [
         [
@@ -186,7 +186,7 @@ SpectrumScaleVagrant\aws\prep-ami>aws ec2 describe-instances --region us-east-1 
     ]
 ]
 
-SpectrumScaleVagrant\aws\prep-ami>
+StorageScaleVagrant\aws\prep-ami>
 ```
 
 ## Appendix: Fix for vagrant-aws packaging

--- a/aws/Vagrantfile
+++ b/aws/Vagrantfile
@@ -1,15 +1,15 @@
 $message = <<EOT
 --------------------------------------------------------------------------
 
-Created virtual environment for IBM Spectrum Scale.
+Created virtual environment for IBM Storage Scale.
 
 User Guide:
-https://github.com/IBM/SpectrumScaleVagrant/blob/master/README.md
+https://github.com/IBM/StorageScaleVagrant/blob/master/README.md
 
 To logon on the management node execute:
 vagrant ssh
 
-To connect to the Spectrum Scale GUI, in a web browser:
+To connect to the Storage Scale GUI, in a web browser:
 https://<AWS Public IP>
 
 --------------------------------------------------------------------------
@@ -17,13 +17,13 @@ EOT
 
 
 # Set provider
-$SpectrumScaleVagrant_provider = 'AWS'
+$StorageScaleVagrant_provider = 'AWS'
 
 
 # Read AWS credentials and ssh keys from shared configuration file
 load File.expand_path('../Vagrantfile.aws-credentials', __FILE__)
 
-# Read AWS AMI ID of the SpectrumScale_base AMI from the configuration file
+# Read AWS AMI ID of the StorageScale_base AMI from the configuration file
 load File.expand_path('../Vagrantfile.aws-ami', __FILE__)
 
 # Load common settings
@@ -66,8 +66,8 @@ Vagrant.configure("2") do |config|
     # aws.region = "eu-central-1"
     aws.region = "us-east-1"
 
-    # Pin the SpectrumScale_base AMI
-    aws.ami = $my_aws_SpectrumScale_base_AMI_ID
+    # Pin the StorageScale_base AMI
+    aws.ami = $my_aws_StorageScale_base_AMI_ID
 
     # Set instance type - default is m3.medium - we need more RAM for CES
     aws.instance_type = "m3.large"
@@ -77,9 +77,9 @@ Vagrant.configure("2") do |config|
 
     # Tag each instance running in AWS with user name
     username = "#{ENV['USERNAME'] || `whoami`}"
-    aws.tags = { 'Name' => "SpectrumScaleVagrant_#{username}" }
+    aws.tags = { 'Name' => "StorageScaleVagrant_#{username}" }
 
-    # Add disks for SpectrumScale NSDs
+    # Add disks for StorageScale NSDs
     aws.block_device_mapping = [
       { 'DeviceName' => '/dev/xvdb', 'Ebs.VolumeSize' =>  3 },
       { 'DeviceName' => '/dev/xvdc', 'Ebs.VolumeSize' =>  3 },
@@ -95,7 +95,7 @@ Vagrant.configure("2") do |config|
 
 
   # Set name of virtual machine used by Vagrant
-  config.vm.define "SpectrumScale_single"
+  config.vm.define "StorageScale_single"
 
   # Set message to be printed after VMs are up and running
   config.vm.post_up_message = $message
@@ -104,18 +104,18 @@ Vagrant.configure("2") do |config|
   config.ssh.keep_alive = true
   config.winssh.keep_alive = true
 
-  # Install and configure single node Spectrum Scale cluster
+  # Install and configure single node Storage Scale cluster
   config.vm.provision "shell",
-    name:   "Install and configure single node Spectrum Scale cluster",
+    name:   "Install and configure single node Storage Scale cluster",
     inline: "
-      /vagrant/install/script.sh #{$SpectrumScaleVagrant_provider} #{$SpectrumScale_version}
+      /vagrant/install/script.sh #{$StorageScaleVagrant_provider} #{$StorageScale_version}
     "
 
-  # Configure Spectrum Scale for demo purposes
+  # Configure Storage Scale for demo purposes
   config.vm.provision "shell",
-    name:   "Configure Spectrum Scale for demo purposes",
+    name:   "Configure Storage Scale for demo purposes",
     inline: "
-      /vagrant/demo/script.sh #{$SpectrumScaleVagrant_provider}
+      /vagrant/demo/script.sh #{$StorageScaleVagrant_provider}
     "
 
 

--- a/aws/Vagrantfile.aws-ami.sample
+++ b/aws/Vagrantfile.aws-ami.sample
@@ -1,5 +1,5 @@
 # Copy this file to Vagrantfile.aws-ami and fill the AMI ID of the
-# SpectrumScale_base AMI that was created according to the README.me
+# StorageScale_base AMI that was created according to the README.me
 
-# The ID of the SpectrumScale_base AMI
-$my_aws_SpectrumScale_base_AMI_ID  = 'xxx'
+# The ID of the StorageScale_base AMI
+$my_aws_StorageScale_base_AMI_ID  = 'xxx'

--- a/aws/prep-ami/Vagrantfile
+++ b/aws/prep-ami/Vagrantfile
@@ -63,16 +63,16 @@ Vagrant.configure("2") do |config|
 
     # Tag each instance with user name
     username = "#{ENV['USERNAME'] || `whoami`}"
-    aws.tags = { 'Name' => "SpectrumScaleVagrant_#{username}" }
+    aws.tags = { 'Name' => "StorageScaleVagrant_#{username}" }
 
-    # Tag derived AMI with 'SpectrumScale_base'
-    aws.package_tags = { 'Name' => "SpectrumScale_base" }
+    # Tag derived AMI with 'StorageScale_base'
+    aws.package_tags = { 'Name' => "StorageScale_base" }
 
   end    
 
 
   # Set name of virtual machine
-  config.vm.define "SpectrumScale_base"
+  config.vm.define "StorageScale_base"
 
   # Set message to be printed after VMs are up and running
   config.vm.post_up_message = $message

--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -15,7 +15,7 @@ in a lab environment. To simplify access from the outside, all virtual
 nodes are configured with well known SSH keys. This is a security exposure
 for production environments.
 
-## SpectrumScale_base.box - A Vagrant box optimized for Storage Scale
+## StorageScale_base.box - A Vagrant box optimized for Storage Scale
 
 The virtual machines are based on the [official Vagrant CentOS/8 boxes](https://app.vagrantup.com/centos/boxes/8).
 Storage Scale requires a couple of additional RPMs. We create a custom
@@ -25,16 +25,16 @@ and the additional CentOS RPMs will be downloaded during the provisioning
 process (`vagrant up`).
 
 To create the custom Vagrant Storage Scale box:
-1. `cd SpectrumScaleVagrant/libvirt/prep-box`
+1. `cd StorageScaleVagrant/libvirt/prep-box`
 2. `vagrant up`
-3. `vagrant package SpectrumScale_base --output SpectrumScale_base.box`
-4. `vagrant box add SpectrumScale_base.box --name SpectrumScale_base`
+3. `vagrant package StorageScale_base --output StorageScale_base.box`
+4. `vagrant box add StorageScale_base.box --name StorageScale_base`
 5. `vagrant destroy`
 
 ## Boot a virtual machine with a single node Storage Scale cluster
 
 Now we are ready to boot a virtual machine on libvirt and to configure it with a single node Storage Scale cluster:
-1. `cd SpectrumScaleVagrant\libvirt`
+1. `cd StorageScaleVagrant\libvirt`
 2. `vagrant up`
 3. `vagrant ssh`
 

--- a/libvirt/Vagrantfile
+++ b/libvirt/Vagrantfile
@@ -11,7 +11,7 @@ $message = <<EOT
 Created virtual environment for IBM Storage Scale.
 
 User Guide:
-https://github.com/IBM/SpectrumScaleVagrant/blob/master/README.md
+https://github.com/IBM/StorageScaleVagrant/blob/master/README.md
 
 To logon on the management node execute:
 vagrant ssh
@@ -24,7 +24,7 @@ EOT
 
 
 # Set provider
-$SpectrumScaleVagrant_provider = 'libvirt'
+$StorageScaleVagrant_provider = 'libvirt'
 
 
 # Load common settings
@@ -34,8 +34,8 @@ load File.expand_path('../../shared/Vagrantfile.common', __FILE__)
 Vagrant.configure("2") do |config|
 
   # Use the Vagrant box prepared for Storage Scale
-  config.vm.box     = "SpectrumScale_base"
-  # config.vm.box_url = "./prep-box/SpectrumScale_base.box"
+  config.vm.box     = "StorageScale_base"
+  # config.vm.box_url = "./prep-box/StorageScale_base.box"
 
   # Customize resources of virtual machines
   config.vm.provider "libvirt" do |libvirt|
@@ -63,6 +63,7 @@ Vagrant.configure("2") do |config|
 
     # Attach five disks for Storage Scale NSDs
     node.vm.provider "libvirt" do |libvirt|
+      libvirt.machine_virtual_size = 15
       # 5 small disks
       # 3 disks will be allocated to fs1, system pool, single failure group
       # 2 disks will be allocated to cesShared, system pool, fg1
@@ -87,14 +88,14 @@ Vagrant.configure("2") do |config|
     node.vm.provision "shell",
       name:   "Install and configure single node Storage Scale cluster",
       inline: "
-        /vagrant/install/script.sh #{$SpectrumScaleVagrant_provider} #{$SpectrumScale_version}
+        /vagrant/install/script.sh #{$StorageScaleVagrant_provider} #{$StorageScale_version}
       "
 
     # Configure Storage Scale for demo purposes
     node.vm.provision "shell",
       name:   "Configure Storage Scale for demo purposes",
       inline: "
-        /vagrant/demo/script.sh #{$SpectrumScaleVagrant_provider}
+        /vagrant/demo/script.sh #{$StorageScaleVagrant_provider}
       "
   end
 end

--- a/libvirt/prep-box/Vagrantfile
+++ b/libvirt/prep-box/Vagrantfile
@@ -12,8 +12,8 @@ Created virtual machine with all RPMs required by IBM Storage Scale. Next
 steps are to create a Vagrant box file and to destroy the virtual machine.
 
 To create a Vagrant box file from virtual machine execute:
-vagrant package SpectrumScale_base --output SpectrumScale_base.box
-vagrant box add SpectrumScale_base.box --name SpectrumScale_base
+vagrant package StorageScale_base --output StorageScale_base.box
+vagrant box add StorageScale_base.box --name StorageScale_base
 
 To destroy the virtual machine execute:
 vagrant destroy
@@ -40,7 +40,7 @@ Vagrant.configure("2") do |config|
   config.vm.box_version = "2011.0"
 
   # Set name of virtual machine
-  config.vm.define "SpectrumScale_base"
+  config.vm.define "StorageScale_base"
 
   # Set message to be printed after VMs are up and running
   config.vm.post_up_message = $message

--- a/setup/demo/README
+++ b/setup/demo/README
@@ -1,10 +1,10 @@
-script.sh     Perform all steps to configure the Spectrum Scale for demo purposes
+script.sh     Perform all steps to configure the Storage Scale for demo purposes
 
 
 script.sh executes the following scripts:
 
-Configure the Spectrum Scale filesystem for demo purposes:
-script-01.sh  Show Spectrum Scale filesystems
+Configure the Storage Scale filesystem for demo purposes:
+script-01.sh  Show Storage Scale filesystems
 script-02.sh  Add second storage pool to filesystem fs1
 script-03.sh  Create placement policy for filesystem fs1
 script-04.sh  - TODO: Placeholder for migration policies -

--- a/setup/demo/script-01.sh
+++ b/setup/demo/script-01.sh
@@ -5,7 +5,7 @@
 echo "========================================================================================="
 echo "===>"
 echo "===> Running $0"
-echo "===> Show Spectrum Scale filesystems"
+echo "===> Show Storage Scale filesystems"
 echo "===>"
 echo "========================================================================================="
 
@@ -16,24 +16,24 @@ set -x
 set -e
 
 
-# Show the global mount status for the whole Spectrum Scale cluster
-echo "===> Show the global mount status for the whole Spectrum Scale cluster"
+# Show the global mount status for the whole Storage Scale cluster
+echo "===> Show the global mount status for the whole Storage Scale cluster"
 mmlsmount all
 
-# Show the default mount point managed by Spectrum Scale
-echo "==> Show the default mount point managed by Spectrum Scale"
+# Show the default mount point managed by Storage Scale
+echo "==> Show the default mount point managed by Storage Scale"
 mmlsfs fs1 -T
 
 # Show the local mount status on the current node
 echo "===> Show the local mount status on the current node"
 mount | grep /ibm/
 
-# Show content of all Spectrum Scale filesystems
-echo "===> Show content of all Spectrum Scale filesystems"
+# Show content of all Storage Scale filesystems
+echo "===> Show content of all Storage Scale filesystems"
 find /ibm/
 
-# Show all Spectrum Scale filesystems using the REST API
-echo "==> Show all Spectrum Scale filesystems using the REST API"
+# Show all Storage Scale filesystems using the REST API
+echo "==> Show all Storage Scale filesystems using the REST API"
 curl -k -s -S -X GET --header 'Accept: application/json' -u admin:admin001 'https://localhost/scalemgmt/v2/filesystems/'
 
 

--- a/setup/demo/script-03.sh
+++ b/setup/demo/script-03.sh
@@ -48,8 +48,8 @@ mmlsattr -L /ibm/fs1/examples/placement_policy/file.hot | grep 'storage pool nam
 echo "===> Show that default file is placed in the capacity storage pool"
 mmlsattr -L /ibm/fs1/examples/placement_policy/file.txt | grep 'storage pool name'
 
-# Show that Spectrum Scale storage pools are not visible to end users
-echo "===> Show that Spectrum Scale storage pools are not visible to end users"
+# Show that Storage Scale storage pools are not visible to end users
+echo "===> Show that Storage Scale storage pools are not visible to end users"
 ls -la /ibm/fs1/examples/placement_policy
 wc -l /ibm/fs1/examples/placement_policy/file*
 

--- a/setup/demo/script-05.sh
+++ b/setup/demo/script-05.sh
@@ -32,13 +32,13 @@ sudo useradd cats          -g pets
 sudo useradd dogs          -g pets
 sudo useradd hamsters      -g pets
 
-# Create Spectrum Scale Filesets
-echo "===> Create Spectrum Scale Filesets"
+# Create Storage Scale Filesets
+echo "===> Create Storage Scale Filesets"
 sudo mmcrfileset fs1 pets    -t "Cute Pets"
 sudo mmcrfileset fs1 flowers -t "Lovely Flowers"
 
-# Link Spectrum Scale Filesets
-echo "===> Link Spectrum Scale Filesets"
+# Link Storage Scale Filesets
+echo "===> Link Storage Scale Filesets"
 sudo mmlinkfileset fs1 pets    -J /ibm/fs1/pets
 sudo mmlinkfileset fs1 flowers -J /ibm/fs1/flowers
 
@@ -67,8 +67,8 @@ for dir in /ibm/fs1/*/* ; do
   done
 done
 
-# Set owner of Spectrum Scale Filesets
-echo "===> Set owner of Spectrum Scale Filesets"
+# Set owner of Storage Scale Filesets
+echo "===> Set owner of Storage Scale Filesets"
 sudo chown admin_flowers:flowers /ibm/fs1/flowers
 sudo chown admin_pets:pets       /ibm/fs1/pets
 

--- a/setup/demo/script.sh
+++ b/setup/demo/script.sh
@@ -12,7 +12,7 @@ usage(){
 echo "========================================================================================="
 echo "===>"
 echo "===> Running $0"
-echo "===> Perform all steps to configure Spectrum Scale for demo purposes"
+echo "===> Perform all steps to configure Storage Scale for demo purposes"
 echo "===>"
 echo "========================================================================================="
 
@@ -39,7 +39,7 @@ case $1 in
     ;;
 esac
 
-# Perform all steps to configure the Spectrum Scale filesystem for demo purposes
+# Perform all steps to configure the Storage Scale filesystem for demo purposes
 /vagrant/demo/script-01.sh
 /vagrant/demo/script-02.sh
 /vagrant/demo/script-03.sh

--- a/setup/files/linux/etc__profile.d__spectrumscale.sh
+++ b/setup/files/linux/etc__profile.d__spectrumscale.sh
@@ -1,4 +1,4 @@
 # Provisioned by Vagrant
 
-# Add Spectrum Scale executables
+# Add Storage Scale executables
 export PATH=$PATH:/usr/lpp/mmfs/bin

--- a/setup/files/linux/etc__sudoers.d__spectrumscale
+++ b/setup/files/linux/etc__sudoers.d__spectrumscale
@@ -1,6 +1,6 @@
 # Provisioned by Vagrant
 
-# Add Spectrum Scale executables
+# Add Storage Scale executables
 Defaults:root       secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/lpp/mmfs/bin
 Defaults:centos     secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/lpp/mmfs/bin
 Defaults:vagrant    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin:/usr/lpp/mmfs/bin

--- a/setup/install/README
+++ b/setup/install/README
@@ -1,12 +1,12 @@
-script.sh     Perform all steps to provision a Spectrum Scale cluster
+script.sh     Perform all steps to provision a Storage Scale cluster
 
               script.sh executes the following scripts:
 
-script-01.sh  Check that Spectrum Scale self-extracting install package exists
-script-02.sh  Extract Spectrum Scale RPMs
-script-03.sh  Setup management node (m1) as Spectrum Scale Install Node
-script-04.sh  Specify Spectrum Scale Cluster
-script-05.sh  Install Spectrum Scale and create a Spectrum Scale cluster
-script-06.sh  Create Spectrum Scale filesystems
+script-01.sh  Check that Storage Scale self-extracting install package exists
+script-02.sh  Extract Storage Scale RPMs
+script-03.sh  Setup management node (m1) as Storage Scale Install Node
+script-04.sh  Specify Storage Scale Cluster
+script-05.sh  Install Storage Scale and create a Storage Scale cluster
+script-06.sh  Create Storage Scale filesystems
 script-07.sh  Tune sensors for demo environment
-script-08.sh  Install Spectrum Scale CES and Object Protocol
+script-08.sh  Install Storage Scale CES and Object Protocol

--- a/setup/install/common-preamble.sh
+++ b/setup/install/common-preamble.sh
@@ -4,7 +4,7 @@ usage(){
   echo "  AWS"
   echo "  VirtualBox"
   echo "  libvirt"
-  echo "<spectrumscale-version> is the full version number like 5.1.7.1"
+  echo "<spectrumscale-version> is the full version number like 5.1.8.0"
 }
 
 # Improve readability of output

--- a/setup/install/script-01.sh
+++ b/setup/install/script-01.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/bash
 
-TASK="Check that Spectrum Scale self-extracting install package exists"
+TASK="Check that Storage Scale self-extracting install package exists"
 
 source /vagrant/install/common-preamble.sh
 
-# Pin the version and the edition of Spectrum Scale, until project runs stable for a while
-install=/software/Spectrum_Scale_Developer-$VERSION-x86_64-Linux-install
-# Abort with error code, if Spectrum Scale self-extracting installation package not found
-echo "===> Check for Spectrum Scale self-extracting installation package"
+# Pin the version and the edition of Storage Scale, until project runs stable for a while
+install=/software/Storage_Scale_Developer-$VERSION-x86_64-Linux-install
+# Abort with error code, if Storage Scale self-extracting installation package not found
+echo "===> Check for Storage Scale self-extracting installation package"
 if [ ! -f $install ]; then
     echo "===> File not found: $install"
     exit 1

--- a/setup/install/script-02.sh
+++ b/setup/install/script-02.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/bash
 
-TASK="Extract Spectrum Scale RPMs"
+TASK="Extract Storage Scale RPMs"
 
 source /vagrant/install/common-preamble.sh
 
-# Pin the version and the edition of Spectrum Scale, until project runs stable for a while
-install=/software/Spectrum_Scale_Developer-$VERSION-x86_64-Linux-install
-# Abort with error code, if Spectrum Scale directroy exists
-echo "===> Check for Spectrum Scale directrory"
+# Pin the version and the edition of Storage Scale, until project runs stable for a while
+install=/software/Storage_Scale_Developer-$VERSION-x86_64-Linux-install
+# Abort with error code, if Storage Scale directroy exists
+echo "===> Check for Storage Scale directrory"
 if [ -d "/usr/lpp/mmfs" ]; then
     echo "===> Directory exists: /usr/lpp/mmfs"
     exit 1
@@ -16,8 +16,8 @@ fi
 # Make self-extracting install package executable
 chmod 555 $install
 
-# Extract Spectrum Scale RPMs
-echo "===> Extract Spectrum Scale PRMs"
+# Extract Storage Scale RPMs
+echo "===> Extract Storage Scale PRMs"
 sudo $install --silent
 
 

--- a/setup/install/script-03.sh
+++ b/setup/install/script-03.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/bash
 
-TASK="Setup management node (m1) as Spectrum Scale Install Node"
+TASK="Setup management node (m1) as Storage Scale Install Node"
 
 source /vagrant/install/common-preamble.sh
 
-# Determine SpectrumScale Install Node
+# Determine StorageScale Install Node
 # ... for AWS
 if [ "$PROVIDER" = "AWS" ]
 then
@@ -16,8 +16,8 @@ then
   INSTALL_NODE="10.1.1.11"
 fi
 
-# Setup management node (m1) as Spectrum Scale Install Node
-echo "===> Setup management node (m1) as Spectrum Scale Install Node"
+# Setup management node (m1) as Storage Scale Install Node
+echo "===> Setup management node (m1) as Storage Scale Install Node"
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale setup -s $INSTALL_NODE --storesecret
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale node list
 

--- a/setup/install/script-04.sh
+++ b/setup/install/script-04.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-TASK="Specify Spectrum Scale Cluster\n===> Target configuration: Single Node Cluster"
+TASK="Specify Storage Scale Cluster\n===> Target configuration: Single Node Cluster"
 
 source /vagrant/install/common-preamble.sh
 

--- a/setup/install/script-05.sh
+++ b/setup/install/script-05.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/bash
 
-TASK="Install Spectrum Scale and create a Spectrum Scale cluster"
+TASK="Install Storage Scale and create a Storage Scale cluster"
 
 source /vagrant/install/common-preamble.sh
 
-# Install Spectrum Scale and create Spectrum Scale cluster
-echo "===> Install Spectrum Scale and create Spectrum Scale cluster"
+# Install Storage Scale and create Storage Scale cluster
+echo "===> Install Storage Scale and create Storage Scale cluster"
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale install
 
 ## Change admin interface
@@ -46,10 +46,10 @@ sudo systemctl status --no-pager pmcollector
 echo "===> Show Zimon Sensors service"
 sudo systemctl status --no-pager pmsensors
 
-# Initialize Spectrum Scale GUI
-# Note: The Spectrum Scale GUI initializes implicitly during first login
+# Initialize Storage Scale GUI
+# Note: The Storage Scale GUI initializes implicitly during first login
 #       attempt. Initializing the GUI here accelerates the first login.
-echo "==> Initialize Spectrum Scale GUI"
+echo "==> Initialize Storage Scale GUI"
 sudo /usr/lpp/mmfs/gui/cli/initgui
 
 

--- a/setup/install/script-06.sh
+++ b/setup/install/script-06.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/bash
 
-TASK="Create Spectrum Scale filesystems"
+TASK="Create Storage Scale filesystems"
 
 source /vagrant/install/common-preamble.sh
 
-# Show Spectrum Scale filesystem specification
+# Show Storage Scale filesystem specification
 echo "===> Show filesystem specification"
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale filesystem list
 
-# Create Spectrum Scale filesystems
-echo "===> Create Spectrum Scale filesystems"
+# Create Storage Scale filesystems
+echo "===> Create Storage Scale filesystems"
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale deploy
 
 # Enable quotas
@@ -17,12 +17,12 @@ echo "===> Enable quotas"
 echo "===> Note: Capacity reports in the GUI depend on enabled quotas"
 sudo mmchfs fs1 -Q yes
 
-# Show Spectrum Scale filesystem configuration
-echo "===> Show Spectrum Scale filesystem configuration"
+# Show Storage Scale filesystem configuration
+echo "===> Show Storage Scale filesystem configuration"
 sudo mmlsfs all
 
-# Show Spectrum Scale filesystem usage
-echo "===> Show Spectrum Scale filesystem usage"
+# Show Storage Scale filesystem usage
+echo "===> Show Storage Scale filesystem usage"
 sudo mmdf fs1
 
 

--- a/setup/install/script.sh
+++ b/setup/install/script.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/bash
 
-TASK="Perform all steps to provision a Spectrum Scale cluster"
+TASK="Perform all steps to provision a Storage Scale cluster"
 
 source /vagrant/install/common-preamble.sh
 
-# Perform all steps to provision Spectrum Scale Cluster
+# Perform all steps to provision Storage Scale Cluster
 /vagrant/install/script-01.sh $PROVIDER $VERSION
 /vagrant/install/script-02.sh $PROVIDER $VERSION
 /vagrant/install/script-03.sh $PROVIDER $VERSION

--- a/shared/Vagrantfile.common
+++ b/shared/Vagrantfile.common
@@ -6,7 +6,7 @@
 # This file should be included by the Vagrantfile of each cluster configuration
 #
 
-$SpectrumScale_version = "5.1.7.1"
+$StorageScale_version = "5.1.8.0"
 
 Vagrant.configure('2') do |config|
 
@@ -22,7 +22,7 @@ Vagrant.configure('2') do |config|
 
   # Configure /etc/hosts
   # ... for AWS
-  if $SpectrumScaleVagrant_provider == 'AWS'
+  if $StorageScaleVagrant_provider == 'AWS'
   then
     config.vm.provision "shell",
       name:   "Configure /etc/hosts for AWS",
@@ -44,7 +44,7 @@ Vagrant.configure('2') do |config|
   end
   # ... for VirtualBox
   # Configure /etc/hosts
-  if $SpectrumScaleVagrant_provider == 'VirtualBox' || $SpectrumScaleVagrant_provider == 'libvirt'
+  if $StorageScaleVagrant_provider == 'VirtualBox' || $StorageScaleVagrant_provider == 'libvirt'
   then
     config.vm.provision "shell",
       name:   "Configure /etc/hosts for VirtualBox",
@@ -54,7 +54,7 @@ Vagrant.configure('2') do |config|
   end
 
   # Generate ssh keys for user root
-  # Note: The Spectrum Scale installation toolkit requires root ssh
+  # Note: The Storage Scale installation toolkit requires root ssh
   config.vm.provision "shell",
     name:   "Generate ssh keys for user root",
     inline: "
@@ -70,7 +70,7 @@ Vagrant.configure('2') do |config|
    "
 
   # Get fingerprint for management IP address
-  if $SpectrumScaleVagrant_provider == 'VirtualBox' || $SpectrumScaleVagrant_provider == 'libvirt'
+  if $StorageScaleVagrant_provider == 'VirtualBox' || $StorageScaleVagrant_provider == 'libvirt'
   then
     config.vm.provision "shell",
       name:   "Get fingerprint for management IP address",
@@ -79,14 +79,14 @@ Vagrant.configure('2') do |config|
      "
   end
 
-  # Add Spectrum Scale executables to $PATH
+  # Add Storage Scale executables to $PATH
   config.vm.provision "shell",
     name:   "Add /usr/lpp/mmfs/bin to $PATH",
     inline: "
       cp /vagrant/files/linux/etc__profile.d__spectrumscale.sh /etc/profile.d/spectrumscale.sh
    "
 
-  # Add Spectrum Scale executables to sudo secure_path
+  # Add Storage Scale executables to sudo secure_path
     config.vm.provision "shell",
     name:   "Add /usr/lpp/mmfs/bin to sudo secure_path",
     inline: "

--- a/shared/Vagrantfile.rpms
+++ b/shared/Vagrantfile.rpms
@@ -2,9 +2,9 @@
 # vi: set ft=ruby :
 
 #
-# RPMs required by Spectrum Scale on top of the base CentOS image
+# RPMs required by Storage Scale on top of the base CentOS image
 #
-# This file should be included by Vagrant files that build a Spectrum Scale
+# This file should be included by Vagrant files that build a Storage Scale
 # base box or image for as specific Vagrant provider
 #
 
@@ -18,18 +18,18 @@ Vagrant.configure('2') do |config|
       /usr/bin/yum upgrade -y
     "
 
-  # Install RPMs required by Spectrum Scale Installation Toolkit
+  # Install RPMs required by Storage Scale Installation Toolkit
   config.vm.provision "shell",
-    name:   "Install RPMs required by Spectrum Scale Installation Toolkit",
+    name:   "Install RPMs required by Storage Scale Installation Toolkit",
     inline: "
       /usr/bin/yum install -y\
         python3\
         net-tools
     "
 
-  # Install RPMs required by Spectrum Scale core
+  # Install RPMs required by Storage Scale core
     config.vm.provision "shell",
-    name:   "Install RPMs required by Spectrum Scale core",
+    name:   "Install RPMs required by Storage Scale core",
     inline: "
       /usr/bin/yum install -y\
         ksh\
@@ -46,9 +46,9 @@ Vagrant.configure('2') do |config|
   #       kernel-headers\
   #  "
 
-  # Install RPMs required by Spectrum Scale to build portability layer
+  # Install RPMs required by Storage Scale to build portability layer
   config.vm.provision "shell",
-    name:   "Install RPMs required by Spectrum Scale to build portability layer",
+    name:   "Install RPMs required by Storage Scale to build portability layer",
     inline: "
       /usr/bin/yum install -y\
         kernel-devel\
@@ -58,9 +58,9 @@ Vagrant.configure('2') do |config|
         gcc-c++
     "
 
-  # Install RPMs required by Spectrum Scale GUI
+  # Install RPMs required by Storage Scale GUI
   config.vm.provision "shell",
-    name:   "Install RPMs required by Spectrum Scale GUI",
+    name:   "Install RPMs required by Storage Scale GUI",
     inline: "
       /usr/bin/yum install -y\
         libpcap\
@@ -71,9 +71,9 @@ Vagrant.configure('2') do |config|
         postgresql-server
     "
 
-  # Install additional RPMs required by Spectrum Scale
+  # Install additional RPMs required by Storage Scale
     config.vm.provision "shell",
-    name:   "Install additional RPMs required by Spectrum Scale",
+    name:   "Install additional RPMs required by Storage Scale",
     inline: "
       /usr/bin/yum install -y\
         boost-regex\

--- a/shared/Vagrantfile8.rpms
+++ b/shared/Vagrantfile8.rpms
@@ -2,9 +2,9 @@
 # vi: set ft=ruby :
 
 #
-# RPMs required by Spectrum Scale on top of the base CentOS image
+# RPMs required by Storage Scale on top of the base CentOS image
 #
-# This file should be included by Vagrant files that build a Spectrum Scale
+# This file should be included by Vagrant files that build a Storage Scale
 # base box or image for as specific Vagrant provider
 #
 
@@ -24,18 +24,18 @@ Vagrant.configure('2') do |config|
       /usr/bin/dnf upgrade -y
     "
 
-  # Install RPMs required by Spectrum Scale Installation Toolkit
+  # Install RPMs required by Storage Scale Installation Toolkit
   config.vm.provision "shell",
-    name:   "Install RPMs required by Spectrum Scale Installation Toolkit",
+    name:   "Install RPMs required by Storage Scale Installation Toolkit",
     inline: "
       /usr/bin/dnf install -y\
         python3\
         net-tools
     "
 
-  # Install RPMs required by Spectrum Scale core
+  # Install RPMs required by Storage Scale core
   config.vm.provision "shell",
-    name:   "Install RPMs required by Spectrum Scale core",
+    name:   "Install RPMs required by Storage Scale core",
     inline: "
       /usr/bin/dnf install -y\
         ksh\
@@ -43,9 +43,9 @@ Vagrant.configure('2') do |config|
         libaio
     "
 
-  # Install RPMs required by Spectrum Scale to build portability layer
+  # Install RPMs required by Storage Scale to build portability layer
   config.vm.provision "shell",
-    name:   "Install RPMs required by Spectrum Scale to build portability layer",
+    name:   "Install RPMs required by Storage Scale to build portability layer",
     inline: "
       /usr/bin/dnf install -y\
         kernel-devel\
@@ -58,9 +58,9 @@ Vagrant.configure('2') do |config|
         make
     "
 
-  # Install RPMs required by Spectrum Scale GUI
+  # Install RPMs required by Storage Scale GUI
   config.vm.provision "shell",
-    name:   "Install RPMs required by Spectrum Scale GUI",
+    name:   "Install RPMs required by Storage Scale GUI",
     inline: "
       /usr/bin/dnf install -y\
         libpcap\
@@ -71,9 +71,9 @@ Vagrant.configure('2') do |config|
         postgresql-server
     "
 
-  # Install additional RPMs required by Spectrum Scale
+  # Install additional RPMs required by Storage Scale
     config.vm.provision "shell",
-    name:   "Install additional RPMs required by Spectrum Scale",
+    name:   "Install additional RPMs required by Storage Scale",
     inline: "
       /usr/bin/dnf install -y\
         boost-regex\
@@ -102,7 +102,7 @@ Vagrant.configure('2') do |config|
 
   # Install Ansible via PIP (RPM installation is broken for Centos8)
   config.vm.provision "shell",
-    name:   "Install Ansible as required by Spectrum Scale 5.1.1+ installer",
+    name:   "Install Ansible as required by Storage Scale 5.1.1+ installer",
     inline: "
       /usr/bin/dnf -y install rust libsodium python3-paramiko python3-pynacl && pip3 install setuptools_rust && pip3 install ansible==2.9.27
     "
@@ -124,7 +124,7 @@ Vagrant.configure('2') do |config|
 
   # Disable EPEL
   config.vm.provision "shell",
-    name:   "Disable EPEL to prevent package conflicts during Spectrum Scale installation",
+    name:   "Disable EPEL to prevent package conflicts during Storage Scale installation",
     inline: "
       /bin/sh -c \"sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/epel*\"
     "

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -16,7 +16,7 @@ in a lab environment. To simplify access from the outside, all virtual
 nodes are configured with well known SSH keys. This is a security exposure
 for production environments.
 
-## SpectrumScale_base.box - A Vagrant box optimized for Storage Scale
+## StorageScale_base.box - A Vagrant box optimized for Storage Scale
 
 The virtual machines are based on the [official Vagrant CentOS/8 boxes](https://app.vagrantup.com/centos/boxes/8).
 Storage Scale requires a couple of additional RPMs. We create a custom 
@@ -26,15 +26,15 @@ and the additional CentOS RPMs will be downloaded during the provisioning
 process (`vagrant up`).
 
 To create the custom Vagrant Storage Scale box:
-1. `cd SpectrumScaleVagrant\virtualbox\prep-box`
+1. `cd StorageScaleVagrant\virtualbox\prep-box`
 1. `vagrant up`
-1. `vagrant package SpectrumScale_base --output SpectrumScale_base.box`
+1. `vagrant package StorageScale_base --output StorageScale_base.box`
 1. `vagrant destroy`
 
 ## Boot a virtual machine with a single node Storage Scale cluster
 
 Now we are ready to boot a virtual machine on VirtualBox and to configure it with a single node Storage Scale cluster:
-1. `cd SpectrumScaleVagrant\virtualbox`
+1. `cd StorageScaleVagrant\virtualbox`
 1. `vagrant up`
 1. `vagrant ssh`
 

--- a/virtualbox/Vagrantfile
+++ b/virtualbox/Vagrantfile
@@ -2,21 +2,21 @@
 # vi: set ft=ruby :
 
 #
-# Create single node Spectrum Scale cluster
+# Create single node Storage Scale cluster
 #
 
 $message = <<EOT
 --------------------------------------------------------------------------
 
-Created virtual environment for IBM Spectrum Scale.
+Created virtual environment for IBM Storage Scale.
 
 User Guide:
-https://github.com/IBM/SpectrumScaleVagrant/blob/master/README.md
+https://github.com/IBM/StorageScaleVagrant/blob/master/README.md
 
 To logon on the management node execute:
 vagrant ssh
 
-To connect to the Spectrum Scale GUI, in a web browser:
+To connect to the Storage Scale GUI, in a web browser:
 https://localhost:8888
 
 --------------------------------------------------------------------------
@@ -24,7 +24,7 @@ EOT
 
 
 # Set provider
-$SpectrumScaleVagrant_provider = 'VirtualBox'
+$StorageScaleVagrant_provider = 'VirtualBox'
 
 
 # Load common settings
@@ -33,9 +33,9 @@ load File.expand_path('../../shared/Vagrantfile.common', __FILE__)
 # Customize configuration specific settings
 Vagrant.configure("2") do |config|
 
-  # Use the Vagrant box prepared for Spectrum Scale
-  config.vm.box     = "SpectrumScale_base"
-  config.vm.box_url = "./prep-box/SpectrumScale_base.box"
+  # Use the Vagrant box prepared for Storage Scale
+  config.vm.box     = "StorageScale_base"
+  config.vm.box_url = "./prep-box/StorageScale_base.box"
 
   # Customize resources of virtual machines
   config.vm.provider "virtualbox" do |vbox|
@@ -57,7 +57,7 @@ Vagrant.configure("2") do |config|
     node.vm.network "private_network", ip: "192.168.56.11"
     node.vm.network "forwarded_port", guest: 443, host: 8888
 
-    # Attach five disks for Spectrum Scale NSDs
+    # Attach five disks for Storage Scale NSDs
     node.vm.provider "virtualbox" do |vbox|
       unless File.exist?("disk")
         vbox.customize ['storagectl', :id, '--name', 'SATA', '--add', 'sata', '--hostiocache', 'off']
@@ -83,21 +83,21 @@ Vagrant.configure("2") do |config|
     # Set message to be printed after VMs are up and running
     config.vm.post_up_message = $message
 
-    # Sync Spectrum Scale install package to admin node
+    # Sync Storage Scale install package to admin node
     config.vm.synced_folder "../software", "/software", type: "rsync"
 
-    # Install and configure single node Spectrum Scale cluster
+    # Install and configure single node Storage Scale cluster
     node.vm.provision "shell",
-      name:   "Install and configure single node Spectrum Scale cluster",
+      name:   "Install and configure single node Storage Scale cluster",
       inline: "
-        /vagrant/install/script.sh #{$SpectrumScaleVagrant_provider} #{$SpectrumScale_version}
+        /vagrant/install/script.sh #{$StorageScaleVagrant_provider} #{$StorageScale_version}
       "
 
-    # Configure Spectrum Scale for demo purposes
+    # Configure Storage Scale for demo purposes
     node.vm.provision "shell",
-      name:   "Configure Spectrum Scale for demo purposes",
+      name:   "Configure Storage Scale for demo purposes",
       inline: "
-        /vagrant/demo/script.sh #{$SpectrumScaleVagrant_provider}
+        /vagrant/demo/script.sh #{$StorageScaleVagrant_provider}
       "
 
   end

--- a/virtualbox/prep-box/Vagrantfile
+++ b/virtualbox/prep-box/Vagrantfile
@@ -2,17 +2,17 @@
 # vi: set ft=ruby :
 
 #
-# Create virtual machine with all RPMs required by Spectrum Scale
+# Create virtual machine with all RPMs required by Storage Scale
 #
 
 $message = <<EOT
 --------------------------------------------------------------------------
 
-Created virtual machine with all RPMs required by IBM Spectrum Scale. Next
+Created virtual machine with all RPMs required by IBM Storage Scale. Next
 steps are to create a Vagrant box file and to destroy the virtual machine.
 
 To create a Vagrant box file from virtual machine execute:
-vagrant package SpectrumScale_base --output SpectrumScale_base.box
+vagrant package StorageScale_base --output StorageScale_base.box
 
 To destroy the virtual machine execute:
 vagrant destroy
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
   config.vm.box_version = "2011.0"
 
   # Set name of virtual machine
-  config.vm.define "SpectrumScale_base"
+  config.vm.define "StorageScale_base"
 
   # Set message to be printed after VMs are up and running
   config.vm.post_up_message = $message


### PR DESCRIPTION
Please note that when you are coming from a previous release, delete your existing instance. Then delete the base vagrant image:
`$ vagrant box remove SpectrumScale_base`

When using libvirt, also remove the backing image
```
$ sudo virsh vol-list default | grep Scale_base
 SpectrumScale_base_vagrant_box_image_0_box.img                      /var/lib/libvirt/images/SpectrumScale_base_vagrant_box_image_0_box.img
$ sudo virsh vol-delete SpectrumScale_base_vagrant_box_image_0_box.img --pool default
```
After doing so, you can re-create the base image, then deploy the VM.