### PR TITLE
Storage Scale 5.1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The creation of the Storage Scale cluster requires the Storage Scale
 self-extracting installation package. The developer edition can be downloaded
 from the [Storage Scale home page](https://www.ibm.com/products/storage-scale).
 
-Download the `Storage_Scale_Developer-5.1.8.2-x86_64-Linux-install` package and
+Download the `Storage_Scale_Developer-5.1.9.0-x86_64-Linux-install` package and
 save it to directory `StorageScaleVagrant/software` on the `host`.
 
 Please note that in case the Storage Scale Developer version you downloaded is
@@ -53,7 +53,7 @@ preferred provider to install and configure a virtual machine.
 
 Please note that for AWS you might want to prefer the new "Cloudkit" Storage
 Scale capability that is also available with the Storage Scale Developer Edition.
-For more details about Cloudkit, please refer to the [documentation](https://www.ibm.com/docs/en/storage-scale/5.1.8?topic=reference-cloudkit).
+For more details about Cloudkit, please refer to the [documentation](https://www.ibm.com/docs/en/storage-scale/5.1.9?topic=reference-cloudkit).
 
 Once the virtual environment is provided, Storage Scale Vagrant uses the same
 scripts to install and configure Storage Scale. Storage Scale Vagrant executes

--- a/aws/README.md
+++ b/aws/README.md
@@ -82,10 +82,10 @@ Copy the Storage Scale self-extracting installation package to `/software`, if y
 StorageScaleVagrant\aws\prep-ami>vagrant ssh
 
 [centos@ip-172-31-27-143 ~]$ ls -l software/
-total 1539696
--rw-r--r--. 1 centos centos        134 31. Mai 11:32 README
--rw-r--r--. 1 centos centos 1576636399  7. Sep 11:58 Storage_Scale_Developer-5.1.8.2-x86_64-Linux-install
--rw-r--r--. 1 centos centos         87  7. Sep 11:58 Storage_Scale_Developer-5.1.8.2-x86_64-Linux-install.md5
+total 1305100
+-rw-r--r--. 1 centos centos        134 31. Mai 2023  README
+-rw-r--r--. 1 centos centos 1336407471 28. Okt 21:32 Storage_Scale_Developer-5.1.9.0-x86_64-Linux-install
+-rw-r--r--. 1 centos centos         87 28. Okt 21:32 Storage_Scale_Developer-5.1.9.0-x86_64-Linux-install.md5
 
 [centos@ip-172-31-27-143 ~]$ exit
 logout

--- a/setup/demo/script.sh
+++ b/setup/demo/script.sh
@@ -47,7 +47,8 @@ esac
 /vagrant/demo/script-05.sh
 /vagrant/demo/script-06.sh
 #/vagrant/demo/script-07.sh
-/vagrant/demo/script-08.sh $PROVIDER
+# Starting with 5.1.9.0, the Swift-based object implementation is no longer supported.
+#/vagrant/demo/script-08.sh $PROVIDER
 
 # Tweak the configuration to show more management capabilities
 /vagrant/demo/script-80.sh

--- a/setup/install/common-preamble.sh
+++ b/setup/install/common-preamble.sh
@@ -4,7 +4,7 @@ usage(){
   echo "  AWS"
   echo "  VirtualBox"
   echo "  libvirt"
-  echo "<spectrumscale-version> is the full version number like 5.1.8.2"
+  echo "<spectrumscale-version> is the full version number like 5.1.9.0"
 }
 
 # Improve readability of output

--- a/setup/install/script-08.sh
+++ b/setup/install/script-08.sh
@@ -9,9 +9,11 @@ sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale node add m1.example.co
 CESVIP=$(grep "cesip" /etc/hosts | awk {'print $1'})
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config protocols -e $CESVIP
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config protocols -f cesShared -m /ibm/cesShared
-sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale enable object
-sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -f fs1 -m /ibm/fs1 -e cesip.example.com -au admin -dp passw0rd -sp passw0rd -ap passw0rd
-sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -s3 on -i 50000
+# Starting with 5.1.9.0, the Swift-based Storage Scale object is no longer
+# supported for new installations.
+#sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale enable object
+#sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -f fs1 -m /ibm/fs1 -e cesip.example.com -au admin -dp passw0rd -sp passw0rd -ap passw0rd
+#sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -s3 on -i 50000
 set +e
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale deploy
 if [ $? != 0 ]; then

--- a/shared/Vagrantfile.common
+++ b/shared/Vagrantfile.common
@@ -6,7 +6,7 @@
 # This file should be included by the Vagrantfile of each cluster configuration
 #
 
-$StorageScale_version = "5.1.8.2"
+$StorageScale_version = "5.1.9.0"
 
 Vagrant.configure('2') do |config|
 


### PR DESCRIPTION
Please note that with Storage Scale 5.1.9.0, Swift Object will no longer be available for new installations, so this fuctionality will also no longer be available in StorageScaleVagrant.
We plan to re-add the follow-on Object solution as soon as it will be available.
