### PR TITLE
Scale 5.1.9.2 support plus additional improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The creation of the Storage Scale cluster requires the Storage Scale
 self-extracting installation package. The developer edition can be downloaded
 from the [Storage Scale home page](https://www.ibm.com/products/storage-scale).
 
-Download the `Storage_Scale_Developer-5.1.9.1-x86_64-Linux-install` package and
+Download the `Storage_Scale_Developer-5.1.9.2-x86_64-Linux-install` package and
 save it to directory `StorageScaleVagrant/software` on the `host`.
 
 Please note that in case the Storage Scale Developer version you downloaded is

--- a/aws/README.md
+++ b/aws/README.md
@@ -82,10 +82,10 @@ Copy the Storage Scale self-extracting installation package to `/software`, if y
 StorageScaleVagrant\aws\prep-ami>vagrant ssh
 
 [centos@ip-172-31-27-143 ~]$ ls -l software/
-total 1303712
+total 1311156
 -rw-r--r--. 1 centos centos        134 31. Mai 2023  README
--rw-r--r--. 1 centos centos 1334987218 29. Nov 17:45 Storage_Scale_Developer-5.1.9.1-x86_64-Linux-install
--rw-r--r--. 1 centos centos         87 29. Nov 17:46 Storage_Scale_Developer-5.1.9.1-x86_64-Linux-install.md5
+-rw-r--r--. 1 centos centos 1342607721  2. Feb 09:31 Storage_Scale_Developer-5.1.9.2-x86_64-Linux-install
+-rw-r--r--. 1 centos centos         87  2. Feb 09:32 Storage_Scale_Developer-5.1.9.2-x86_64-Linux-install.md5
 
 [centos@ip-172-31-27-143 ~]$ exit
 logout

--- a/setup/install/common-preamble.sh
+++ b/setup/install/common-preamble.sh
@@ -4,7 +4,7 @@ usage(){
   echo "  AWS"
   echo "  VirtualBox"
   echo "  libvirt"
-  echo "<spectrumscale-version> is the full version number like 5.1.9.1"
+  echo "<spectrumscale-version> is the full version number like 5.1.9.2"
 }
 
 # Improve readability of output

--- a/setup/install/script-04.sh
+++ b/setup/install/script-04.sh
@@ -20,7 +20,7 @@ sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale node add -a -g -q -m -
 echo "===> Show cluster specification"
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale node list
 
-# Specify NSDs
+# Specify NSDs and file systems
 # ... for AWS
 if [ "$PROVIDER" = "AWS" ]
 then
@@ -42,6 +42,14 @@ then
   sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com -fs cesShared /dev/vde /dev/vdf
   sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale nsd add -p m1.example.com /dev/vdg /dev/vdh
 fi
+
+# Reduce the amount of nodes to keep the Scale metadata size small
+# Unfortunately this can not be changed using the installation toolkit, so patch it manually
+sudo dnf -y install jq
+tmp=$(sudo mktemp)
+clusterdef=/usr/lpp/mmfs/$VERSION/ansible-toolkit/ansible/vars/scale_clusterdefinition.json
+sudo jq '.scale_filesystem[].numNodes = "1"' $clusterdef > $tmp
+sudo mv $tmp $clusterdef
 
 # Show NSD specification
 echo "===> Show NSD specification"

--- a/setup/install/script-07.sh
+++ b/setup/install/script-07.sh
@@ -13,6 +13,9 @@ sudo mmperfmon config update \
   GPFSFilesetQuota.period=300 \
   GPFSDiskCap.period=300
 
+echo "===> Mute expected mmhealth tips"
+sudo mmhealth event hide callhome_not_enabled
+sudo mmhealth event hide unexpected_operating_system
 
 # Exit successfully
 echo "===> Script completed successfully!"

--- a/setup/install/script-08.sh
+++ b/setup/install/script-08.sh
@@ -14,6 +14,7 @@ sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config protocols -f ce
 #sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale enable object
 #sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -f fs1 -m /ibm/fs1 -e cesip.example.com -au admin -dp passw0rd -sp passw0rd -ap passw0rd
 #sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale config object -s3 on -i 50000
+
 set +e
 sudo /usr/lpp/mmfs/$VERSION/ansible-toolkit/spectrumscale deploy
 if [ $? != 0 ]; then

--- a/shared/Vagrantfile.common
+++ b/shared/Vagrantfile.common
@@ -6,7 +6,7 @@
 # This file should be included by the Vagrantfile of each cluster configuration
 #
 
-$StorageScale_version = "5.1.9.1"
+$StorageScale_version = "5.1.9.2"
 
 Vagrant.configure('2') do |config|
 


### PR DESCRIPTION
Add Scale 5.1.9.2 support.
Fix #38 and also mute unexpected OS health event.
Reduce metadata overhead for single-node deployment.